### PR TITLE
Fixes #11 - Gzip

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,12 +109,12 @@ filters:
 - **Pattern:**
     - The regular expression which will be used to find data in the file.
     - Regular expression must be compatible with the python `re` module in the standard library.
-    - Be sure that your regular expression only contains ONE capture group. For example,
+    - Be sure that your regular expression only contains ONE and ONLY ONE capture group. For example,
     if you are capturing a phone number:
         - Don't do this: `'(555-(867|555)-5309)'`
         - Do this: `'(555-(?:867|555)-5309)'`
-        - The first has two capture groups, and inner and an outer.
-        - The second has one capture group (the outer). The inner is a non-capturing
+        - The former example has two capture groups, and inner and an outer.
+        - The latter has one capture group (the outer). The inner is a non-capturing
         group as defined by starting the capture group with `?:`.
     - __Note: If you run into issues with loading a custom filter, try adding
     single-quotes around your regular expression.__

--- a/README.md
+++ b/README.md
@@ -251,6 +251,10 @@ sanity check which can be paired with a DLP solution. Here are some things it wa
     - No outrageous licensing per GB of data scanned.
 - __You can contribute!__
 
+# Version
+
+### 0.0.3 - 2019-06-01
+- Added gzip detection and streaming.
 
 
 # Development

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Identify and classify data in your text files with Python.
 ## Description
 **Definition:** txtferret
 - A weasel-like mammal that feasts on rodents... and apparently social security numbers,
-credit card numbers, or any other data that's in your text files.
+credit card numbers, or any other data that's in your text or gzipped text files.
 
 Use custom regular expressions and sanity checks (ex: `luhn` algorithm for account numbers) to find
 sensitive data in virtually any size file via your command line.
@@ -251,10 +251,10 @@ sanity check which can be paired with a DLP solution. Here are some things it wa
     - No outrageous licensing per GB of data scanned.
 - __You can contribute!__
 
-# Version
+## Releases
 
-### 0.0.3 - 2019-06-01
-- Added gzip detection and streaming.
+#### Version 0.0.3 - 2019-06-01
+- Added gzip detection and support.
 
 
 # Development

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from setuptools import setup, find_packages
 from codecs import open
 from os import path
 
-__version__ = "0.0.2"
+__version__ = "0.0.3"
 description = "Scan text files for sensitive (or non-sensitive) data."
 
 here = path.abspath(path.dirname(__file__))

--- a/src/txtferret/_sanity.py
+++ b/src/txtferret/_sanity.py
@@ -18,8 +18,9 @@ def luhn(account_string):
         test.
     """
 
+    # TODO - Is there a more effecient way to do this?
     if not isinstance(account_string, str):
-        account_string = account_string.decode('utf-8')
+        account_string = account_string.decode("utf-8")
 
     no_special_chars = re.sub("[\W_]", "", account_string)
 

--- a/src/txtferret/_sanity.py
+++ b/src/txtferret/_sanity.py
@@ -18,6 +18,9 @@ def luhn(account_string):
         test.
     """
 
+    if not isinstance(account_string, str):
+        account_string = account_string.decode('utf-8')
+
     no_special_chars = re.sub("[\W_]", "", account_string)
 
     try:

--- a/src/txtferret/core.py
+++ b/src/txtferret/core.py
@@ -23,10 +23,19 @@ def tokenize(clear_text, mask, index, tokenize=True, show_matches=False):
     :param show_matches: Bool representing whether the clear text should
         be redacted all together or not.
     """
+
     if not show_matches:
         return "REDACTED"
+
+    # byte string can be present if source file is Gzipped
+    # convert to utf-8 string for logging/file output.
+    if not isinstance(clear_text, str):
+        clear_text = clear_text.decode("utf-8")
+        mask = mask.decode("utf-8")
+
     if not tokenize:
         return clear_text
+
     return _get_tokenized_string(clear_text, mask, index)
 
 
@@ -37,10 +46,6 @@ def _get_tokenized_string(text, mask, index):
         than the original string, then the mask will be cut down to
         size.
     """
-    # TODO - Need tests for decode
-    if not isinstance(text, str):
-        text = text.decode("utf-8")
-        mask = mask.decode("utf-8")
 
     end_index = index + len(mask)
     text_length = len(text)
@@ -186,7 +191,10 @@ class TxtFerret:
         self.gzip = gzipped_file_check(self.file_name)
 
         if self.gzip:
-            logger.info("Detected non-text file... attempting GZIP mode (slower).")
+            logger.info(
+                f"Detected non-text file '{file_name}'... "
+                f"attempting GZIP mode (slower)."
+            )
 
         # Set settings from file.
         self.set_attributes(**config["settings"])

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -1,0 +1,35 @@
+from contextlib import contextmanager
+
+from txtferret.core import gzipped_file_check
+
+
+def test_gzipped_file_check_return_true():
+
+    @contextmanager
+    def opener_stub_raise_error(x, y):
+
+        class FileHandlerStub:
+
+            @staticmethod
+            def readline():
+                raise UnicodeDecodeError("fake", b"o", 1, 2, "fake")
+
+        yield FileHandlerStub()
+
+    assert gzipped_file_check("f.txt", _opener=opener_stub_raise_error) == True
+
+
+def test_gzipped_file_check_return_false():
+
+    @contextmanager
+    def opener_stub_no_error(x, y):
+
+        class FileHandlerStub:
+
+            @staticmethod
+            def readline():
+                return ""
+
+        yield FileHandlerStub()
+
+    assert gzipped_file_check("f.txt", _opener=opener_stub_no_error) == False


### PR DESCRIPTION
Instead of just looking for one of the gzip-specific bits (like 0x8b),  at the start of the program execution we attempt to open and read one line from the file. If we get back an UnicodeDecodeError, then we switch to the gzip file hander returned from gzip.open(). This is the naive part since we just assume the file is gzipped; However, when the file is actually opened for reading, it should raise an uncaught exception if the file is also not a gzip file. Might be nice to add a more informative error, but that's not a part of this pull.

We set a flag 'TxtFerret.gzip' to True.

By doing this so early in the program, we can then convert the filter strings (regex and masks) to bytes before iterating through lines of the file. These regex byte strings can be matched against byte strings supplied by the gzip file hander.

One alternative is to do string encoding/decoding during each line read of a gzipped file; However, that would cause a performance hit.

We do have to make a switch back to utf-8 when logging to stdout or to the output file, but this is done just before logging. Otherwise, a goofy b'' will be added around the string splices.