### PR TITLE
Ignore columns Fixes #17

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ settings:
   output_file:
   show_matches: Yes
   delimiter:
+  ignore_columns: [1, 5, 6]
 ```
 - **bulk**
     - This setting is accessible via CLI arguments `-b` or `--bulk`.
@@ -264,6 +265,12 @@ settings:
     $ txtferret scan -d , ../fake_ccn_CSV_file.csv
     2019:05:20-01:12:18:-0400 PASSED sanity and matched regex - Filter: fake_ccn_account_filter, Line 1, String: 10XXXXXXXXXXXXXXXXXXX, Column: 3
     ```
+ - **ignore_columns**
+    - This setting is ignored if the `delimiter` setting or switch is not set.
+    - Add a list of integers and txtferret will skip those columns.
+    - If `ignore_columns: [2, 6]` is configured and a csv row is `hello,world,how,are,you,doing,today`, then
+    `world` and `doing` will not be scanned but will be ignored.
+    - This is particularly useful in columnar datasets when you know there is a column that is full of false positives.
 
 # How/why did this come about?
 
@@ -304,8 +311,8 @@ sanity check which can be paired with a DLP solution. Here are some things it wa
 ## Releases
 
 #### Version 0.1.0 - 2019-07-30
-- Removed the `config-override` option
-
+- Removed the `config-override` option.
+- Added `ignore_columns` setting.
 #### Version 0.0.4 - 2019-06-09
 - Added bulk file scanning by the `--bulk` switch.
 - Added multiprocessing for bulk scanning.

--- a/src/txtferret/_config.py
+++ b/src/txtferret/_config.py
@@ -25,6 +25,7 @@ _allowed_settings_keys = {
     "output_file",
     "show_matches",
     "delimiter",
+    "ignore_columns",
 }
 
 

--- a/src/txtferret/_default.py
+++ b/src/txtferret/_default.py
@@ -13,6 +13,7 @@ settings:
   output_file:
   show_matches: Yes
   delimiter:
+  ignore_columns:
 
 filters:
   - label: american_express_15_ccn

--- a/src/txtferret/core.py
+++ b/src/txtferret/core.py
@@ -230,6 +230,25 @@ class TxtFerret:
             if setting not in _allowed_settings_keys:
                 continue
 
+            # ignore_columns will not be a switch, so we want to go
+            # ahead and handle it here instead of trying to determine
+            # if it's a cli_argument further down.
+            if setting == "ignore_columns":
+                if value is not None and value:
+                    value = {int(column) for column in value}
+                    self.ignore_columns = value
+
+                    print_string = ", ".join(
+                        [str(col_num) for col_num in sorted(self.ignore_columns)]
+                    )
+                    logger.info(f"Columns set to be ignored: {print_string}")
+
+                    continue
+                # If it is None or empty, make it an empty set
+                self.ignore_columns = set()
+
+
+
             # If the current setting has no value, check to see if
             # the object already has an attribute of the same name.
             # If it does not, then we assume this is the original
@@ -300,6 +319,7 @@ class TxtFerret:
 
         logger.info(f"Finished scan for {self.file_name}")
 
+
     def _scan_delimited_line(self, line, index):
         """Scan a delimited line.
 
@@ -307,7 +327,6 @@ class TxtFerret:
         :param index: The line number.
         """
         for filter_ in self.filters:
-            column_map = {}
 
             # Make sure to convert to bytecode/hex if necessary.
             # For example... Start Of Header (SOH).
@@ -318,20 +337,9 @@ class TxtFerret:
             else:
                 columns = line.split(delimiter.encode('utf-8'))
 
-            # Look for matches in each column.
-            for i, column in enumerate(columns):
-                matches = filter_.regex.findall(column)
-
-                if not matches:
-                    continue
-
-                # Fill out column_map
-                for match in matches:
-                    j = str(i)
-                    if j not in column_map:
-                        column_map[j] = []
-
-                    column_map[j].append(match)
+            column_map = get_column_map(
+                columns=columns, filter_=filter_, ignore_columns=self.ignore_columns
+            )
 
             for column_number, column_match_list in column_map.items():
                 for column_match in column_match_list:
@@ -394,6 +402,43 @@ class TxtFerret:
 
                 if not self.summarize:
                     log_success(self.file_name, filter_, index, string_to_log)
+
+
+# TODO get_column_map needs tests.
+def get_column_map(columns=None, filter_=None, ignore_columns=None):
+    """ Return a dict containing columns and their regex matches
+
+    :param columns: List of the columns to scan
+    :param filter_: The filter object that contains the regular
+        expression to use when scanning the column.
+    :ignore_columns: A set containing column numbers which should be
+        ignored and not scanned.
+    """
+
+    column_map = {}
+
+    for i, column in enumerate(columns):
+
+        # Skip this column if the config says to ignore it.
+        if (i + 1) in ignore_columns:
+            continue
+
+        matches = filter_.regex.findall(column)
+
+        if not matches:
+            continue
+
+        # Fill out the column_map with {"index": "match"}
+        for match in matches:
+            j = str(i)
+            # In case there are multiple matches in a column.
+            if j not in column_map:
+                column_map[j] = []
+
+            column_map[j].append(match)
+
+    return column_map
+
 
 
 def sanity_test(filter_, text, sanity_func=None):

--- a/src/txtferret/core.py
+++ b/src/txtferret/core.py
@@ -12,7 +12,7 @@ from ._sanity import sanity_check
 
 
 def tokenize(
-        clear_text, mask, index, tokenize=True, show_matches=False, tokenize_func=None,
+    clear_text, mask, index, tokenize=True, show_matches=False, tokenize_func=None
 ):
     """Return string as redacted, tokenized format, or clear text.
 
@@ -238,6 +238,7 @@ class TxtFerret:
                     value = {int(column) for column in value}
                     self.ignore_columns = value
 
+                    # Let the user know which columns are being ignored
                     print_string = ", ".join(
                         [str(col_num) for col_num in sorted(self.ignore_columns)]
                     )
@@ -246,8 +247,6 @@ class TxtFerret:
                     continue
                 # If it is None or empty, make it an empty set
                 self.ignore_columns = set()
-
-
 
             # If the current setting has no value, check to see if
             # the object already has an attribute of the same name.
@@ -319,7 +318,6 @@ class TxtFerret:
 
         logger.info(f"Finished scan for {self.file_name}")
 
-
     def _scan_delimited_line(self, line, index):
         """Scan a delimited line.
 
@@ -335,7 +333,7 @@ class TxtFerret:
             if not self.gzip:
                 columns = line.split(delimiter)
             else:
-                columns = line.split(delimiter.encode('utf-8'))
+                columns = line.split(delimiter.encode("utf-8"))
 
             column_map = get_column_map(
                 columns=columns, filter_=filter_, ignore_columns=self.ignore_columns
@@ -438,7 +436,6 @@ def get_column_map(columns=None, filter_=None, ignore_columns=None):
             column_map[j].append(match)
 
     return column_map
-
 
 
 def sanity_test(filter_, text, sanity_func=None):


### PR DESCRIPTION
Added `ignore_columns` setting.
- If `delimiter` setting or switch is not set, then the `ignore_columns` setting is ignored
- Not available as a switch
- Input is a list of integers
- If column number (index + 1) is in the list, then the column is not scanned
- Handy for columnar data in which you know a column is riddled with false positives

Also moved some of the column scanning logic to its own function to move toward easier testing.