### PR TITLE
Added substitute functionality to filters. Fixes #18

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ as it is logged to a file or displayed on a terminal.
 filters:
 - label: american_express_15_ccn
   pattern: '((?:34|37)\d{2}(?:(?:[\W_]\d{6}[\W_]\d{5})|\d{11}))'
+  substitute: '[\W_]'
   sanity: luhn
   tokenize:
     index: 2,
@@ -162,6 +163,10 @@ filters:
         group as defined by starting the capture group with `?:`.
     - __Note: If you run into issues with loading a custom filter, try adding
     single-quotes around your regular expression.__
+- **Substitute:**
+    - Allows you to define what characters are removed from a string before it is passed to the sanity check(s).
+    - Must be a valid regular expression.
+    - If missing or empty, the default substitute is `[\W_]`.
 - **Sanity:**
     - This is the algorithm to use with this filter in order to validate the data is really what you're
     looking for. For example, 16 digits might just be a random number and not a credit card. Putting the
@@ -310,6 +315,8 @@ sanity check which can be paired with a DLP solution. Here are some things it wa
 
 ## Releases
 
+#### Version 0.1.1 - 2019-07-30
+- Added `substitute` option to filters.
 #### Version 0.1.0 - 2019-07-30
 - Removed the `config-override` option.
 - Added `ignore_columns` setting.

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from setuptools import setup, find_packages
 from codecs import open
 from os import path
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 description = "Scan text files for sensitive (or non-sensitive) data."
 
 here = path.abspath(path.dirname(__file__))

--- a/src/txtferret/_config.py
+++ b/src/txtferret/_config.py
@@ -9,7 +9,7 @@ from ._default import default_yaml
 _allowed_top_level = {"filters", "settings"}
 
 # Keys allowed for a filter in the config YAML file.
-_allowed_filter_keys = {"label", "type", "pattern", "tokenize", "sanity"}
+_allowed_filter_keys = {"label", "type", "pattern", "tokenize", "sanity", "substitute"}
 
 # Keys allowed for the filter.tokenize values.
 _allowed_token_keys = {"mask", "index"}

--- a/src/txtferret/_default.py
+++ b/src/txtferret/_default.py
@@ -5,6 +5,10 @@ IF YOU WILL BE CHANGING THIS CONFIG FILE, be sure that you update the
 validation functions and tests for _config.py.
 """
 
+
+default_substitute = "[\W_]"
+
+
 default_yaml = """
 settings:
   tokenize: Yes
@@ -20,6 +24,7 @@ filters:
     type: Credit Card Number
     sanity: luhn
     pattern: '((?:34|37)\d{2}(?:(?:[\W_]\d{6}[\W_]\d{5})|\d{11}))'
+    substitute: '[\W_]'
     tokenize:
       mask: XXXXXXXXXXXXX
       index: 2
@@ -27,6 +32,7 @@ filters:
     type: Credit Card Number
     sanity: luhn
     pattern: '(4\d{3}(?:(?:[\W_]\d{4}){3}|\d{12}))'
+    substitute: '[\W_]'
     tokenize:
       mask: XXXXXXXXXXXXXXX
       index: 1
@@ -34,6 +40,7 @@ filters:
     type: Credit Card Number
     sanity: luhn
     pattern: '(5[1-5]\d{2}(?:(?:[\W_]\d{4}){3}|\d{12}))'
+    substitute: '[\W_]'
     tokenize:
       mask: XXXXXXXXXXXXXX
       index: 2
@@ -41,6 +48,7 @@ filters:
     type: Credit Card Number
     sanity: luhn
     pattern: '(6011(?:(?:[\W_]\d{4}){3}|\d{12}))'
+    substitute: '[\W_]'
     tokenize:
       mask: XXXXXXXXXXXX
       index: 4
@@ -48,6 +56,7 @@ filters:
     type: Credit Card Number
     sanity: luhn
     pattern: '((?:30[0-5]\d|3[68]\d{2})(?:(?:[\W_]\d{6}[\W_]\d{4})|\d{10}))'
+    substitute: '[\W_]'
     tokenize:
       mask: XXXXXXXXXXXX
       index: 2

--- a/src/txtferret/_sanity.py
+++ b/src/txtferret/_sanity.py
@@ -19,10 +19,10 @@ def luhn(account_string):
     """
 
     # TODO - Is there a more effecient way to do this?
-    if not isinstance(account_string, str):
-        account_string = account_string.decode("utf-8")
+    # if not isinstance(account_string, str):
+    #     account_string = account_string.decode("utf-8")
 
-    no_special_chars = re.sub("[\W_]", "", account_string)
+    # no_special_chars = re.sub("[\W_]", "", account_string)
 
     try:
         # doubled_tuple:
@@ -30,8 +30,8 @@ def luhn(account_string):
         # difference of the index doubled and 9. This is required
         # as part of the luhn calculations.
         doubled_tuple = (0, 2, 4, 6, 8, 1, 3, 5, 7, 9)
-        evens = sum(int(even_num) for even_num in no_special_chars[-1::-2])
-        odds = sum(doubled_tuple[int(odd_num)] for odd_num in no_special_chars[-2::-2])
+        evens = sum(int(even_num) for even_num in account_string[-1::-2])
+        odds = sum(doubled_tuple[int(odd_num)] for odd_num in account_string[-2::-2])
     except ValueError:
         raise ValueError("Luhn algorithm input must convert to int.")
     else:

--- a/tests/_sanity/test_sanity.py
+++ b/tests/_sanity/test_sanity.py
@@ -38,17 +38,6 @@ def test_luhn_with_failing_account_num(bad_luhn_fake_account_num):
     assert isinstance(rv, bool), "Return value should be a bool"
 
 
-def test_luhn_with_passing_account_num_and_delims(good_luhn_fake_account_num_delims):
-    rv = luhn(good_luhn_fake_account_num_delims)
-    assert  rv == True, "Should have returned True"
-    assert isinstance(rv, bool), "Return value should be a bool"
-
-def test_luhn_with_failing_account_num_and_delims(bad_luhn_fake_account_num_delims):
-    rv = luhn(bad_luhn_fake_account_num_delims)
-    assert  rv == False, "Should have returned False"
-    assert isinstance(rv, bool), "Return value should be a bool"
-
-
 def test_luhn_for_value_error():
     non_int = "123abc"
     with pytest.raises(ValueError) as e_info:
@@ -78,6 +67,9 @@ def always_false_algorithm_stub():
         return False
 
     return stub_func
+
+
+# TODO Add tests for if substitution is set to False in sanity_check
 
 
 def test_sanity_check_passes_sanity(always_true_algorithm_stub):

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -109,6 +109,7 @@ def test_sanity_for_failed_sanity_check():
 
     class StubFilter:
         sanity = ["fake"]
+        substitute = "who_cares"
 
     assert sanity_test(StubFilter, "some_text", sanity_func=stub_func) == False
 
@@ -120,5 +121,6 @@ def test_sanity_for_passed_sanity_checks():
 
     class StubFilter:
         sanity = ["sanity1", "sanity2", "sanity3"]
+        substitute = "who_cares"
 
     assert sanity_test(StubFilter, "some_text", sanity_func=stub_func)


### PR DESCRIPTION
Added substitute functionality
- Allows you to define what characters are removed from a string before it is passed to the sanity check(s).
- Must be a valid regular expression.
- If missing or empty, the default substitute is `[\W_]`.
