### PR TITLE
Fixed bug with regex and gzip introduced in version 0.1.1 Fixes #27

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,8 @@ sanity check which can be paired with a DLP solution. Here are some things it wa
 
 ## Releases
 
+#### Version 0.1.2 - 2019-08-01
+- Fixed bug with regex when reading gzipped files.
 #### Version 0.1.1 - 2019-07-30
 - Added `substitute` option to filters.
 #### Version 0.1.0 - 2019-07-30

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from setuptools import setup, find_packages
 from codecs import open
 from os import path
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 description = "Scan text files for sensitive (or non-sensitive) data."
 
 here = path.abspath(path.dirname(__file__))

--- a/src/txtferret/_sanity.py
+++ b/src/txtferret/_sanity.py
@@ -19,8 +19,8 @@ def luhn(account_string):
     """
 
     # TODO - Is there a more effecient way to do this?
-    # if not isinstance(account_string, str):
-    #     account_string = account_string.decode("utf-8")
+    if not isinstance(account_string, str):
+        account_string = account_string.decode("utf-8")
 
     # no_special_chars = re.sub("[\W_]", "", account_string)
 
@@ -34,6 +34,9 @@ def luhn(account_string):
         odds = sum(doubled_tuple[int(odd_num)] for odd_num in account_string[-2::-2])
     except ValueError:
         raise ValueError("Luhn algorithm input must convert to int.")
+    except Exception:
+        print(account_string)
+        raise
     else:
         return (evens + odds) % 10 == 0
 

--- a/src/txtferret/core.py
+++ b/src/txtferret/core.py
@@ -143,6 +143,7 @@ class Filter:
 
         self.type = filter_dict.get("type", "NOT_DEFINED")
         self.sanity = filter_dict.get("sanity", "")
+        self.empty = ""  # Used in re.sub in 'sanity_check'
 
         # Sanity should be a list of strings. If just a string, convert
         # it to a list with a single element.
@@ -164,6 +165,7 @@ class Filter:
             self.token_mask = self.token_mask.encode("utf-8")
             self.pattern = self.pattern.encode("utf-8")
             self.substitute = self.substitute.encode("utf-8")
+            self.empty = b""  # Used in re.sub in 'sanity_check'
 
         try:
             self.token_index = int(filter_dict["tokenize"].get("index", 0))
@@ -465,7 +467,7 @@ def sanity_test(filter_, text, sub=True, sanity_func=None):
     _sanity_checker = sanity_func or sanity_check
 
     if sub:
-        _text = re.sub(filter_.substitute, "", text)
+        _text = re.sub(filter_.substitute, filter_.empty, text)
     else:
         _text = text
 

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -12,12 +12,9 @@ from txtferret.core import (
 
 
 def test_gzipped_file_check_return_true():
-
     @contextmanager
     def opener_stub_raise_error(x, y):
-
         class FileHandlerStub:
-
             @staticmethod
             def readline():
                 raise UnicodeDecodeError("fake", b"o", 1, 2, "fake")
@@ -28,12 +25,9 @@ def test_gzipped_file_check_return_true():
 
 
 def test_gzipped_file_check_return_false():
-
     @contextmanager
     def opener_stub_no_error(x, y):
-
         class FileHandlerStub:
-
             @staticmethod
             def readline():
                 return ""
@@ -54,20 +48,22 @@ def test_tokenize_return_clear_text():
 
 
 def test_tokenize_runs_tokenization_function():
-
     def stub_func(arg1, arg2, arg3):
         return "stub was called"
 
-    assert tokenize("hello", "XXX", 0, show_matches=True, tokenize_func=stub_func)\
-           == "stub was called"
+    assert (
+        tokenize("hello", "XXX", 0, show_matches=True, tokenize_func=stub_func)
+        == "stub was called"
+    )
 
 
 def test_tokenize_for_byte_return():
     def stub_func(arg1, arg2, arg3):
         return (arg1, arg2, arg3)
 
-    assert tokenize(b"hello", b"XXX", 0, show_matches=True, tokenize_func=stub_func)\
-           == ("hello", "XXX", 0)
+    assert tokenize(
+        b"hello", b"XXX", 0, show_matches=True, tokenize_func=stub_func
+    ) == ("hello", "XXX", 0)
 
 
 def test_get_tokenized_string_normal():
@@ -103,24 +99,24 @@ def test_byte_code_to_string_start_of_header():
 
 
 def test_sanity_for_failed_sanity_check():
-
     def stub_func(a, b):
         return False
 
     class StubFilter:
         sanity = ["fake"]
         substitute = "who_cares"
+        empty = ""
 
     assert sanity_test(StubFilter, "some_text", sanity_func=stub_func) == False
 
 
 def test_sanity_for_passed_sanity_checks():
-
     def stub_func(a, b):
         return True
 
     class StubFilter:
         sanity = ["sanity1", "sanity2", "sanity3"]
         substitute = "who_cares"
+        empty = ""
 
     assert sanity_test(StubFilter, "some_text", sanity_func=stub_func)


### PR DESCRIPTION
For the empty string in the substitution process before passing to sanity check, I added the empty string as an attribute of the Filter object. That way, we can set the string to bytes string at creation time of the filter (one time per filter at the beginning of the script) instead of doing so before each substitution (ex: before each time we pass the string to sanity checks...yuck).