### PR TITLE
Minor 0.2.0 Fixes #24

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Why use txtferret?  See the __How/why did this come about?__ section below.
     
     $ txtferret scan my_test_file.dat
     2019:05:20-22:18:01:-0400 Beginning scan for /home/mrferret/Documents/test_file_1.dat
-    2019:05:20-22:18:18:-0400 PASSED sanity and matched regex - /home/mrferret/Documents/test_file_1.dat - Filter: visa_16_ccn, Line 712567, String: 4XXXXXXXXXXXXXXX
+    2019:05:20-22:18:18:-0400 PASSED sanity and matched regex - /home/mrferret/Documents/test_file_1.dat - Filter: fake_ccn_account_filter, Line 712567, String: 100102030405060708094
     2019:05:20-22:19:09:-0400 Finished scan for /home/mrferret/Documents/test_file_1.dat
     2019:05:20-22:19:09:-0400 SUMMARY:
     2019:05:20-22:19:09:-0400   - Matched regex, failed sanity: 2
@@ -73,7 +73,7 @@ Why use txtferret?  See the __How/why did this come about?__ section below.
     
     $ txtferret scan --delimiter , test_file_1.csv
     2019:05:20-21:41:57:-0400 Beginning scan for /home/mrferret/Documents/test_file_1.csv
-    2019:05:20-21:44:34:-0400 PASSED sanity and matched regex - /home/mrferret/Documents/test_file_1.csv - Filter: visa_16_ccn, Line 712567, String: 4XXXXXXXXXXXXXXX, Column: 171
+    2019:05:20-21:44:34:-0400 PASSED sanity and matched regex - /home/mrferret/Documents/test_file_1.csv - Filter: fake_ccn_account_filter, Line 712567, String: 100102030405060708094, Column: 171
     2019:05:20-21:49:16:-0400 Finished scan for /home/mrferret/Documents/test_file_1.csv
     2019:05:20-21:49:16:-0400 SUMMARY:
     2019:05:20-21:49:16:-0400   - Matched regex, failed sanity: 2
@@ -90,10 +90,10 @@ Why use txtferret?  See the __How/why did this come about?__ section below.
     2019:06:09-15:15:27:-0400 Beginning scan for /home/mrferret/Documents/test_file_1.dat.gz
     2019:06:09-15:15:27:-0400 Beginning scan for /home/mrferret/Documents/test_file_2.dat.gz
     2019:06:09-15:15:27:-0400 Beginning scan for /home/mrferret/Documents/test_file_3.dat
-    2019:06:09-15:15:27:-0400 PASSED sanity and matched regex - /home/mrferret/Documents/test_file_2.dat.gz - Filter: visa_16_ccn, Line 4, String: 4XXXXXXXXXXXXXXX026
+    2019:06:09-15:15:27:-0400 PASSED sanity and matched regex - /home/mrferret/Documents/test_file_2.dat.gz - Filter: fake_ccn_account_filter, Line 4, String: 100102030405060708094
     2019:06:09-15:15:27:-0400 Finished scan for /home/mrferret/Documents/test_file_2.dat.gz
-    2019:06:09-15:16:04:-0400 PASSED sanity and matched regex - /home/mrferret/Documents/test_file_3.dat - Filter: visa_16_ccn, Line 712567, String: 4XXXXXXXXXXXXXXX
-    2019:06:09-15:16:51:-0400 PASSED sanity and matched regex - /home/mrferret/Documents/test_file_1.dat.gz - Filter: visa_16_ccn, Line 712567, String: 4XXXXXXXXXXXXXXX
+    2019:06:09-15:16:04:-0400 PASSED sanity and matched regex - /home/mrferret/Documents/test_file_3.dat - Filter: fake_ccn_account_filter, Line 712567, String: 100102030405060708094
+    2019:06:09-15:16:51:-0400 PASSED sanity and matched regex - /home/mrferret/Documents/test_file_1.dat.gz - Filter: fake_ccn_account_filter, Line 712567, String: 100102030405060708094
     2019:06:09-15:17:15:-0400 Finished scan for /home/mrferret/Documents/test_file_3.dat
     2019:06:09-15:19:24:-0400 Finished scan for /home/mrferret/Documents/test_file_1.dat.gz
     2019:06:09-15:19:24:-0400 SUMMARY:
@@ -143,15 +143,15 @@ filters:
   pattern: '((?:34|37)\d{2}(?:(?:[\W_]\d{6}[\W_]\d{5})|\d{11}))'
   substitute: '[\W_]'
   sanity: luhn
-  tokenize:
+  mask:
     index: 2,
-    mask: XXXXXXXX
+    value: XXXXXXXX
   type: Credit Card Number
 ```
 
-- **Label:**
+- **label:**
     - This will be displayed in the logs when the filter in question has matched a string.
-- **Pattern:**
+- **pattern:**
     - The regular expression which will be used to find data in the file.
     - Regular expression must be compatible with the python `re` module in the standard library.
     - Be sure that your regular expression only contains ONE and ONLY ONE capture group. For example,
@@ -163,30 +163,30 @@ filters:
         group as defined by starting the capture group with `?:`.
     - __Note: If you run into issues with loading a custom filter, try adding
     single-quotes around your regular expression.__
-- **Substitute:**
+- **substitute:**
     - Allows you to define what characters are removed from a string before it is passed to the sanity check(s).
     - Must be a valid regular expression.
     - If missing or empty, the default substitute is `[\W_]`.
-- **Sanity:**
+- **sanity:**
     - This is the algorithm to use with this filter in order to validate the data is really what you're
     looking for. For example, 16 digits might just be a random number and not a credit card. Putting the
     numbers through the `luhn` algorithm will validate they could potentially be an account number and
     reduce false positives.
     - You can also pass through a list of strings that represent algorithms as long as the algorithm exists
     in the library. If not, please add it and make a pull request!
-- **Tokenize:**
+- **mask:**
     - index:
-        - This is the position in the matched string in which the tokenization will begin.
-    - mask
-        - The string which will be used to tokenize the matched string.
-- **Type:**
+        - This is the position in the matched string in which the masking will begin.
+    - value
+        - The string which will be used to mask the matched string.
+- **type:**
     - This is basically a description of the 'type' of data you're looking for with this filter.
 
 ### Settings
 
 ```yaml
 settings:
-  tokenize: Yes
+  mask: No
   log_level: INFO
   summarize: No
   output_file:
@@ -202,16 +202,16 @@ settings:
     ```bash
     $ txtferret scan --bulk /home/mrferret/Documents
     ```
-- **tokenize**
-    - If set to true, the token mask defined in the filter will be used to mask the data during output.
-    - If no mask is set for a filter, the program will tokenize with a default mask.
+- **mask**
+    - If set to true, the mask value defined in the filter will be used to mask the data during output.
+    - If no mask is set for a filter, the program will mask with a default mask value.
     - This is set to 'true' by default.
-    - **CLI** - The `-nt` switch can be used to turn off tokenization'
+    - **CLI** - The `-m` switch can be used to turn on masking'
     ```bash
-    $ txtferret scan ../fake_ccn_data.txt
+    $ txtferret scan -m ../fake_ccn_data.txt
     2017:05:20-00:24:52:-0400 PASSED sanity and matched regex - Filter: fake_ccn_account_filter, Line 1, String: 10XXXXXXXXXXXXXXXXXXX
   
-    $ txtferret scan -nt ../fake_ccn_data.txt
+    $ txtferret scan ../fake_ccn_data.txt
     2017:05:20-00:26:18:-0400 PASSED sanity and matched regex - Filter: fake_ccn_account_filter, Line 1, String: 100102030405060708094
     ```
 - **log_level:**
@@ -221,10 +221,10 @@ settings:
     - **CLI** - The `-l` switch will allow you to change log levels:
     ```bash
     $ txtferret scan ../fake_ccn_data.txt
-    2019:05:20-00:36:00:-0400 PASSED sanity and matched regex - Filter: fake_ccn_account_filter, Line 1, String: 10XXXXXXXXXXXXXXXXXXX
+    2019:05:20-00:36:00:-0400 PASSED sanity and matched regex - Filter: fake_ccn_account_filter, Line 1, String: 100102030405060708094
   
     $ txtferret scan -l DEBUG ../fake_ccn_data.txt
-    2019:05:20-01:02:07:-0400 PASSED sanity and matched regex - Filter: fake_ccn_account_filter, Line 1, String: 10XXXXXXXXXXXXXXXXXXX
+    2019:05:20-01:02:07:-0400 PASSED sanity and matched regex - Filter: fake_ccn_account_filter, Line 1, String: 100102030405060708094
     2019:05:20-01:02:07:-0400 FAILED sanity and matched regex - Filter: fake_ccn_account_filter, Line: 2
     ```
 - **summarize**
@@ -235,7 +235,7 @@ settings:
     - **CLI** - The `-s` switch will kickoff the summary.
     ```bash
     $ txtferret scan ../fake_ccn_data.txt
-    2019:05:20-00:36:00:-0400 PASSED sanity and matched regex - Filter: fake_ccn_account_filter, Line 1, String: 10XXXXXXXXXXXXXXXXXXX
+    2019:05:20-00:36:00:-0400 PASSED sanity and matched regex - Filter: fake_ccn_account_filter, Line 1, String: 100102030405060708094
  
     $ txtferret scan -s ../fake_ccn_data.txt
     2019:05:20-01:05:29:-0400 SUMMARY:
@@ -264,12 +264,12 @@ settings:
     - **CLI** - Use the `-d` switch to set a delimiter and scan per column instead of line.
     ```bash
     $ txtferret scan ../fake_ccn_data.txt
-    2019:05:20-00:36:00:-0400 PASSED sanity and matched regex - Filter: fake_ccn_account_filter, Line 1, String: 10XXXXXXXXXXXXXXXXXXX
+    2019:05:20-00:36:00:-0400 PASSED sanity and matched regex - Filter: fake_ccn_account_filter, Line 1, String: 100102030405060708094
     
     # Comma delimiter
 
     $ txtferret scan -d , ../fake_ccn_CSV_file.csv
-    2019:05:20-01:12:18:-0400 PASSED sanity and matched regex - Filter: fake_ccn_account_filter, Line 1, String: 10XXXXXXXXXXXXXXXXXXX, Column: 3
+    2019:05:20-01:12:18:-0400 PASSED sanity and matched regex - Filter: fake_ccn_account_filter, Line 1, String: 100102030405060708094, Column: 3
     ```
  - **ignore_columns**
     - This setting is ignored if the `delimiter` setting or switch is not set.
@@ -311,14 +311,18 @@ sanity check which can be paired with a DLP solution. Here are some things it wa
     - Indicates which line the string was found.
     - Indicates which column if you've defined a delimiter (ex: comma for CSV files).
     - You can choose to mask your output data to make sure you're not putting sensitive data
-    into your log files or outputting them to your terminal.
-    - You can also turn off masking/tokenization so that you can see exactly what was matched. 
+    into your log files or outputting them to your terminal. 
 - __It's free__
     - No contracts
     - No outrageous licensing per GB of data scanned.
 - __You can contribute!__
 
 ## Releases
+
+#### Version 0.2.0 - 2019-08-05
+- Changed `tokenize` to `mask` because tokenize was a lie.. it's masking.
+    - Replaced `--no-tokenize` switch with `--mask` switch.
+- Turned masking off by default.
 
 #### Version 0.1.3 - 2019-08-05
 - Added `file_encoding` setting for multi-encoding support.

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from setuptools import setup, find_packages
 from codecs import open
 from os import path
 
-__version__ = "0.1.3"
+__version__ = "0.2.0"
 description = "Scan text files for sensitive (or non-sensitive) data."
 
 here = path.abspath(path.dirname(__file__))

--- a/src/txtferret/_config.py
+++ b/src/txtferret/_config.py
@@ -1,4 +1,3 @@
-import os
 
 import yaml
 
@@ -6,10 +5,10 @@ from ._default import DEFAULT_YAML
 
 
 # Keys allowed in top lovel of config.
-_allowed_top_level = {"filters", "settings"}
+ALLOWED_TOP_LEVEL = {"filters", "settings"}
 
 # Keys allowed for a filter in the config YAML file.
-_allowed_filter_keys = {
+ALLOWED_FILTER_KEYS = {
     "label",
     "type",
     "pattern",
@@ -20,13 +19,13 @@ _allowed_filter_keys = {
 }
 
 # Keys allowed for the filter.tokenize values.
-_allowed_token_keys = {"mask", "index"}
+ALLOWED_MASK_KEYS = {"mask", "index"}
 
 # Keys required for a filter to pass validation.
-_required_filter_keys = {"label", "pattern"}
+REQUIRED_FILTER_KEYS = {"label", "pattern"}
 
 # Keys allowed for settings section in the config YAML file.
-_allowed_settings_keys = {
+ALLOWED_SETTINGS_KEYS = {
     "tokenize",
     "log_level",
     "summarize",
@@ -148,7 +147,7 @@ def validate_config(
     """
     # Make sure only allowed values at top level of config.
     top_level_keys = set(config_dict.keys())
-    allowed_top_level = top_level or _allowed_top_level
+    allowed_top_level = top_level or ALLOWED_TOP_LEVEL
 
     if not subset_check(subset=top_level_keys, set_=allowed_top_level):
         raise ValueError("Bad config: One or more top-lvel keys are not allowed.")
@@ -158,7 +157,7 @@ def validate_config(
         for filter_ in config_dict["filters"]:
 
             _filter_keys = set(filter_.keys())
-            allowed_filter_keys = filter_keys or _allowed_filter_keys
+            allowed_filter_keys = filter_keys or ALLOWED_FILTER_KEYS
 
             if not subset_check(subset=_filter_keys, set_=allowed_filter_keys):
                 raise ValueError("Bad config: One or more filter keys are not allowed.")
@@ -166,7 +165,7 @@ def validate_config(
             # Note, the set order is switched up here as we want to find
             # which keys in the subset (required) are NOT in the main
             # set (The actual keys).
-            required_filter_keys = required_keys or _required_filter_keys
+            required_filter_keys = required_keys or REQUIRED_FILTER_KEYS
 
             if not subset_check(subset=required_filter_keys, set_=_filter_keys):
                 raise ValueError(
@@ -176,9 +175,9 @@ def validate_config(
             if filter_.get("tokenize", None) is not None:
 
                 _token_keys = set(filter_["tokenize"].keys())
-                allowed_token_keys = token_keys or _allowed_token_keys
+                allowed_mask_keys = token_keys or ALLOWED_MASK_KEYS
 
-                if not subset_check(subset=_token_keys, set_=allowed_token_keys):
+                if not subset_check(subset=_token_keys, set_=allowed_mask_keys):
                     raise ValueError(
                         "Bad config: One or more filter token keys is not allowed."
                     )
@@ -187,7 +186,7 @@ def validate_config(
     if "settings" in config_dict:
 
         _settings_keys = set(config_dict["settings"].keys())
-        allowed_settings_keys = settings_keys or _allowed_settings_keys
+        allowed_settings_keys = settings_keys or ALLOWED_SETTINGS_KEYS
 
         if not subset_check(subset=_settings_keys, set_=allowed_settings_keys):
             raise ValueError("Bad config: One or more settings are not allowed.")

--- a/src/txtferret/_default.py
+++ b/src/txtferret/_default.py
@@ -26,7 +26,7 @@ filters:
   - label: american_express_15_ccn
     type: Credit Card Number
     sanity: luhn
-    pattern: '((?:34|37)\d{2}(?:(?:[\W_]\d{6}[\W_]\d{5})|\d{11}))'
+    pattern: '((?:34|37)[0-9]{2}(?:(?:[\W_][0-9]{6}[\W_][0-9]{5})|[0-9]{11}))'
     substitute: '[\W_]'
     mask:
       value: XXXXXXXXXXXXX
@@ -34,7 +34,7 @@ filters:
   - label: visa_16_ccn
     type: Credit Card Number
     sanity: luhn
-    pattern: '(4\d{3}(?:(?:[\W_]\d{4}){3}|\d{12}))'
+    pattern: '(4[0-9]{3}(?:(?:[\W_][0-9]{4}){3}|[0-9]{12}))'
     substitute: '[\W_]'
     mask:
       value: XXXXXXXXXXXXXXX
@@ -42,7 +42,7 @@ filters:
   - label: master_card_16_ccn
     type: Credit Card Number
     sanity: luhn
-    pattern: '(5[1-5]\d{2}(?:(?:[\W_]\d{4}){3}|\d{12}))'
+    pattern: '(5[1-5][0-9]{2}(?:(?:[\W_][0-9]{4}){3}|[0-9]{12}))'
     substitute: '[\W_]'
     mask:
       value: XXXXXXXXXXXXXX
@@ -50,7 +50,7 @@ filters:
   - label: discover_16_ccn
     type: Credit Card Number
     sanity: luhn
-    pattern: '(6011(?:(?:[\W_]\d{4}){3}|\d{12}))'
+    pattern: '(6011(?:(?:[\W_][0-9]{4}){3}|[0-9]{12}))'
     substitute: '[\W_]'
     mask:
       value: XXXXXXXXXXXX
@@ -58,7 +58,7 @@ filters:
   - label: diners_carte_14_ccn
     type: Credit Card Number
     sanity: luhn
-    pattern: '((?:30[0-5]\d|3[68]\d{2})(?:(?:[\W_]\d{6}[\W_]\d{4})|\d{10}))'
+    pattern: '((?:30[0-5][0-9]|3[68][0-9]{2})(?:(?:[\W_][0-9]{6}[\W_][0-9]{4})|[0-9]{10}))'
     substitute: '[\W_]'
     mask:
       value: XXXXXXXXXXXX

--- a/src/txtferret/_default.py
+++ b/src/txtferret/_default.py
@@ -7,13 +7,13 @@ validation functions and tests for _config.py.
 
 DEFAULT_SUBSTITUTE = "[\W_]"
 DEFAULT_ENCODING = "utf-8"
-DEFAULT_TOKEN_MASK = "XXXXXXXXXXXXXXX"
-DEFAULT_TOKEN_INDEX = 0
+DEFAULT_MASK_VALUE = "XXXXXXXXXXXXXXX"
+DEFAULT_MASK_INDEX = 0
 
 
 DEFAULT_YAML = """
 settings:
-  tokenize: Yes
+  value: No
   log_level: INFO
   summarize: No
   output_file:
@@ -28,39 +28,39 @@ filters:
     sanity: luhn
     pattern: '((?:34|37)\d{2}(?:(?:[\W_]\d{6}[\W_]\d{5})|\d{11}))'
     substitute: '[\W_]'
-    tokenize:
-      mask: XXXXXXXXXXXXX
+    mask:
+      value: XXXXXXXXXXXXX
       index: 2
   - label: visa_16_ccn
     type: Credit Card Number
     sanity: luhn
     pattern: '(4\d{3}(?:(?:[\W_]\d{4}){3}|\d{12}))'
     substitute: '[\W_]'
-    tokenize:
-      mask: XXXXXXXXXXXXXXX
+    mask:
+      value: XXXXXXXXXXXXXXX
       index: 1
   - label: master_card_16_ccn
     type: Credit Card Number
     sanity: luhn
     pattern: '(5[1-5]\d{2}(?:(?:[\W_]\d{4}){3}|\d{12}))'
     substitute: '[\W_]'
-    tokenize:
-      mask: XXXXXXXXXXXXXX
+    mask:
+      value: XXXXXXXXXXXXXX
       index: 2
   - label: discover_16_ccn
     type: Credit Card Number
     sanity: luhn
     pattern: '(6011(?:(?:[\W_]\d{4}){3}|\d{12}))'
     substitute: '[\W_]'
-    tokenize:
-      mask: XXXXXXXXXXXX
+    mask:
+      value: XXXXXXXXXXXX
       index: 4
   - label: diners_carte_14_ccn
     type: Credit Card Number
     sanity: luhn
     pattern: '((?:30[0-5]\d|3[68]\d{2})(?:(?:[\W_]\d{6}[\W_]\d{4})|\d{10}))'
     substitute: '[\W_]'
-    tokenize:
-      mask: XXXXXXXXXXXX
+    mask:
+      value: XXXXXXXXXXXX
       index: 2
 """

--- a/src/txtferret/_default.py
+++ b/src/txtferret/_default.py
@@ -13,7 +13,7 @@ DEFAULT_MASK_INDEX = 0
 
 DEFAULT_YAML = """
 settings:
-  value: No
+  mask: No
   log_level: INFO
   summarize: No
   output_file:

--- a/src/txtferret/_sanity.py
+++ b/src/txtferret/_sanity.py
@@ -1,5 +1,3 @@
-import re
-
 
 def luhn(account_string, _encoding):
     """Return bool if string passes Luhn test.

--- a/src/txtferret/cli.py
+++ b/src/txtferret/cli.py
@@ -128,10 +128,10 @@ def cli():
 
 @click.command()
 @click.option(
-    "--no-tokenize",
-    "-nt",
+    "--mask",
+    "-m",
     is_flag=True,
-    help="When set, the output from the scan will not be tokenized.",
+    help="When set, the data found while scanning will be masked when output.",
 )
 @click.option(
     "--log-level",

--- a/src/txtferret/core.py
+++ b/src/txtferret/core.py
@@ -7,7 +7,7 @@ import re
 
 from loguru import logger
 
-from ._config import _allowed_settings_keys
+from ._config import ALLOWED_SETTINGS_KEYS
 from ._sanity import sanity_check
 from ._default import (
     DEFAULT_SUBSTITUTE,
@@ -80,7 +80,7 @@ def _byte_code_to_string(byte_code, _encoding):
 
     :return: UTF-8 version of byte-code.
     """
-    match = re.match(b"b(\d{1,3})", byte_code)
+    match = re.match(b"b([0-9]{1,3})", byte_code)
     if not match:
         return byte_code
     code_ = int(match.group(1))
@@ -258,7 +258,7 @@ class TxtFerret:
                     continue
                 self.mask = True
 
-            if setting not in _allowed_settings_keys:
+            if setting not in ALLOWED_SETTINGS_KEYS:
                 continue
 
             # ignore_columns will not be a switch, so we want to go

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -4,8 +4,8 @@ import pytest
 
 from txtferret.core import (
     gzipped_file_check,
-    tokenize,
-    _get_tokenized_string,
+    mask,
+    _get_masked_string,
     _byte_code_to_string,
     sanity_test,
 )
@@ -37,42 +37,42 @@ def test_gzipped_file_check_return_false():
     assert gzipped_file_check("f.txt", _opener=opener_stub_no_error) == False
 
 
-def test_tokenize_not_show_matches():
+def test_mask_not_show_matches():
 
-    assert tokenize("hello", "XXX", 0, show_matches=False) == "REDACTED"
-
-
-def test_tokenize_return_clear_text():
-
-    assert tokenize(b"hello", b"XXX", 0, tokenize=False, show_matches=True) == b"hello"
+    assert mask("hello", "XXX", 0, show_matches=False) == "REDACTED"
 
 
-def test_tokenize_runs_tokenization_function():
+def test_mask_return_clear_text():
+
+    assert mask(b"hello", b"XXX", 0, show_matches=True) == b"hello"
+
+
+def test_mask_runs_mask_function():
     def stub_func(arg1, arg2, arg3):
         return "stub was called"
 
     assert (
-        tokenize(b"hello", b"XXX", 0, show_matches=True, tokenize_func=stub_func)
+        mask(b"hello", b"XXX", 0, mask=True, show_matches=True, mask_func=stub_func)
         == b"stub was called"
     )
 
 
-def test_get_tokenized_string_normal():
+def test_get_masked_string_normal():
 
     text = "howdy"
     mask = "XXX"
     index = 1
 
-    assert _get_tokenized_string(text, mask, index) == "hXXXy"
+    assert _get_masked_string(text, mask, index) == "hXXXy"
 
 
-def test_get_tokenized_string_mask_too_long():
+def test_get_masked_string_mask_too_long():
 
     text = "howdy"
     mask = "XXXXX"
     index = 1
 
-    assert _get_tokenized_string(text, mask, index) == "hXXXX"
+    assert _get_masked_string(text, mask, index) == "hXXXX"
 
 
 def test_byte_code_to_string_no_byte_string():


### PR DESCRIPTION
- Changed `no-tokenize` feature to `mask` feature. Tokenization was a lie. We're just masking.
- Previous default was to mask. New default is to leave in clear text.
- Removed old switch of `-nt` or `--no-tokenize`, and replaced with `-m` and `--mask` for more intuitive API.